### PR TITLE
let edn.lua also handle ; symbol

### DIFF
--- a/edn.lua
+++ b/edn.lua
@@ -68,6 +68,13 @@ local function read_token(cr)
   local from = cr.pos()
   if c == nil then
     return nil
+  elseif c == ";" then
+    -- Skip comment until newline
+    while c ~= nil and c ~= "\n" do
+      cr.advance()
+      c = cr.current()
+    end
+    return read_token(cr)
   elseif c == "(" or c == ")" or c == "[" or c == "]" or c == "{" or c == "}" then
     cr.advance()
     return {c, nil, from, cr.pos()}


### PR DESCRIPTION
The original `edn.lua` does not handle the `;` symbol. 

Therefore, when I used it with [autoconjure](https://github.com/Olical/conjure/issues/318), it breaks at the `;` symbol. 

The way that I test it:
1. Prepare conjure/fennel environment 
2. prepare the following file. 

```
(local {: autoload} (require :nfnl.module))
(local a (autoload :nfnl.core))
(local {: decode} (autoload :edn))
(local nvim vim.api)

(fn shadow-cljs-content []
  (a.slurp :shadow-cljs.edn))

(fn build-key [tbl]
  (a.first (a.keys (a.get tbl :builds))))

(fn shadow_build_id []
  (build-key (decode (shadow-cljs-content))))

{: shadow_build_id}
```

3. execute the form ` (decode (shadow-cljs-content))`